### PR TITLE
Clean up recipe kwargs

### DIFF
--- a/docs/example/all_recipes.jl
+++ b/docs/example/all_recipes.jl
@@ -144,7 +144,7 @@ savefig("recipe_pdfit.svg"); #md #hide
 fitdat_vw = @df pd_data PrimaryDryFit(:t, (:T1[:t .< 13u"hr"],
                                     :T2[:t .< 13u"hr"]); 
                                     Tvws=:T3[:t .< 16u"hr"],)
-plot(fitdat_vw, nmarks=40)
+plot(fitdat_vw, nmarks=40, showline=true, linealpha=0.3)
 savefig("recipe_pdfitvw.svg"); #md #hide
 # ![](recipe_pdfitvw.svg) #md
 
@@ -155,7 +155,7 @@ plot(Tsh, tmax=5u"hr")
 savefig("recipe_rv.svg"); #md #hide
 # ![](recipe_rv.svg) #md
 
-plot(pch)
+plot(pch, ylim=(0u"mTorr", 150u"mTorr"))
 
 # # Example models
 # ## Conventional lyophilization
@@ -230,7 +230,7 @@ sol_rf = solve(prob, Rodas3());
 # # Plot Recipes for Solution Objects
 
 # For conventional drying, we only need to plot temperatures of the frozen layer:
-modconvtplot(sol_conv, showmarks=true)
+modconvtplot(sol_conv, showmarks=true, marker=:circle)
 savefig("recipe_pikal.svg"); #md #hide
 # ![](recipe_pikal.svg) #md
 

--- a/docs/example/all_recipes.jl
+++ b/docs/example/all_recipes.jl
@@ -87,8 +87,8 @@ savefig("recipe_pressure_alt.svg"); #md #hide
 # ![](recipe_pressure_alt.svg) #md
 
 # ## Temperature plotting
-@df procdata exptfplot(:t, :T1, :T2, nmarks=40, sampmarks=true, linealpha=0.2)
-@df procdata exptvwplot!(:t, :T3, nmarks=30, sampmarks=true, linealpha=0.2)
+@df procdata exptfplot(:t, :T1, :T2, nmarks=40, showline=true, linealpha=0.2)
+@df procdata exptvwplot!(:t, :T3, nmarks=30, showline=true, linealpha=0.2)
 savefig("recipe_temp.svg"); #md #hide
 # ![](recipe_temp.svg) #md
 
@@ -230,7 +230,7 @@ sol_rf = solve(prob, Rodas3());
 # # Plot Recipes for Solution Objects
 
 # For conventional drying, we only need to plot temperatures of the frozen layer:
-modconvtplot(sol_conv, sampmarks=true)
+modconvtplot(sol_conv, showmarks=true)
 savefig("recipe_pikal.svg"); #md #hide
 # ![](recipe_pikal.svg) #md
 
@@ -240,7 +240,7 @@ savefig("recipe_multipikal.svg") #hide
 # ![](recipe_multipikal.svg) #md
 
 # For microwave-assisted drying, we also need to plot vial wall temperatures:
-modrftplot(sol_rf, sampmarks=true)
+modrftplot(sol_rf, showmarks=true)
 savefig("recipe_rf.svg"); #md #hide
 # ![](recipe_rf.svg) #md
 

--- a/docs/example/fitting_mannitol.jl
+++ b/docs/example/fitting_mannitol.jl
@@ -64,7 +64,7 @@ pd_data.t .-= pd_data.t[1]
 
 # ## Identify one definition of end of primary drying with Savitzky-Golay filter
 
-t_end = identify_pd_end(pd_data.t, pd_data.pirani, Val(:der2))
+t_end = identify_pd_end(pd_data.t, pd_data.pirani, Val(:onoff))
 
 # Plots provides a very convenient macro `@df` which inserts table columns into a function call,
 # which is very handy for plotting. Here this is combined with a recipe for plotting the pressure:

--- a/docs/example/fitting_rf_mannitol.jl
+++ b/docs/example/fitting_rf_mannitol.jl
@@ -78,7 +78,7 @@ pch = RampedVariable(100u"mTorr")
 
 # We will also need to know when primary drying *actually* ends, 
 # so we will use the second-derivative test in Pirani-CM convergence. 
-# This identifies the end of primary drying as the minimum in second derivative,
+# This identifies the end of primary drying as the maximum in second derivative,
 # which generally occurs close to the convergence of the two pressure measurements.
 t_end = identify_pd_end(lyo_pd.t, lyo_pd.pch_pir, Val(:der2))
 @df lyo_pd plot(:t, :pch_pir)

--- a/docs/example/fitting_rf_mannitol.jl
+++ b/docs/example/fitting_rf_mannitol.jl
@@ -80,7 +80,7 @@ pch = RampedVariable(100u"mTorr")
 # so we will use the second-derivative test in Pirani-CM convergence. 
 t_end = identify_pd_end(lyo_pd.t, lyo_pd.pch_pir, Val(:der2))
 @df lyo_pd plot(:t, :pch_pir)
-@df plot!(:t, pch_pir_sm)
+@df lyo_pd plot!(:t, pch_pir_sm)
 tendplot!(t_end)
 
 

--- a/docs/example/fitting_rf_mannitol.jl
+++ b/docs/example/fitting_rf_mannitol.jl
@@ -78,9 +78,11 @@ pch = RampedVariable(100u"mTorr")
 
 # We will also need to know when primary drying *actually* ends, 
 # so we will use the second-derivative test in Pirani-CM convergence. 
+# This identifies the end of primary drying as the minimum in second derivative,
+# which generally occurs close to the convergence of the two pressure measurements.
 t_end = identify_pd_end(lyo_pd.t, lyo_pd.pch_pir, Val(:der2))
 @df lyo_pd plot(:t, :pch_pir)
-@df lyo_pd plot!(:t, pch_pir_sm)
+@df lyo_pd plot!(:t, :pch_cm)
 tendplot!(t_end)
 
 

--- a/docs/example/utilities.jl
+++ b/docs/example/utilities.jl
@@ -142,7 +142,7 @@ plot!(Tsh3, lw=3, label="2 ramps")
 fitdat_all = @df pd_data PrimaryDryFit(:t, (:T1[:t .< 15u"hr"],
                                     :T2[:t .< 13u"hr"],
                                     :T3[:t .< 16u"hr"]),)
-plot(fitdat_all, nmarks=30, sampmarks=true)
+plot(fitdat_all, nmarks=30, showmarks=true)
 
 # Note that in this plot, T1 rises after 13 hours--I have deliberately included that
 # to show what this will do in $R_p(h_d)$ space.

--- a/docs/example/utilities.jl
+++ b/docs/example/utilities.jl
@@ -142,7 +142,7 @@ plot!(Tsh3, lw=3, label="2 ramps")
 fitdat_all = @df pd_data PrimaryDryFit(:t, (:T1[:t .< 15u"hr"],
                                     :T2[:t .< 13u"hr"],
                                     :T3[:t .< 16u"hr"]),)
-plot(fitdat_all, nmarks=30, showmarks=true)
+plot(fitdat_all, nmarks=30, showline=true)
 
 # Note that in this plot, T1 rises after 13 hours--I have deliberately included that
 # to show what this will do in $R_p(h_d)$ space.

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -150,17 +150,17 @@ exptvwplot
             markercolor --> :white
             markerstrokecolor --> pal[i]
             markerstrokewidth --> 1.5
+            minlen = min(length(time), length(T))
             if showline || get(plotattributes, :linewidth, 0) > 0
                 linestyle --> :dash
-                time_skip = time[begin:skip:end]
-                T_skip = T[begin:skip:end]
+                time_skip = time[begin:skip:minlen]
+                T_skip = T[begin:skip:minlen]
                 seriestype := :samplemarkers
                 step = (nmarks == Inf) ? 1 : (size(time_skip, 1) ÷ nmarks) 
                 step := step
                 offset := step÷n *(i-1) + 1
                 return time_skip, T_skip
             else
-                minlen = min(length(time), length(T))
                 seriestype --> :scatter
                 step = nmarks == Inf ? 1 : (size(time, 1) ÷ nmarks) 
                 offset = step÷n *(i-1) + 1
@@ -512,6 +512,7 @@ exppplot
         @series begin
             seriestype --> :samplemarkers
             step --> length(p) ÷ 10
+            linewidth --> 2
             ylabel --> "Pressure"
             label --> defaultlabels[i]
             return t, p

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -92,13 +92,11 @@ exptfplot
             label --> labels[i]
             seriescolor --> pal[i]
             if showline || get(plotattributes, :linewidth, 0) > 0
-                @info "A" step
                 seriestype := :samplemarkers
                 step := step
                 offset := step÷n *(i-1) + 1
                 return time[eachindex(T)], T
             else
-                @info "B" step
                 seriestype --> :scatter
                 offset = step÷n *(i-1) + 1
                 minlen = min(length(time), length(T))

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -7,15 +7,17 @@
     n = length(y)
     sx, sy = x[offset:step:n], y[offset:step:n]
     # add an empty series with the correct type for legend markers
+    lw = get(plotattributes, :linewidth, :auto)
     markershape = get(plotattributes, :markershape, :auto)
+    visible_line = lw == :auto || lw > 0
     @series begin
-        seriestype := :path
+        seriestype := (visible_line ? :path : :scatter)
         markershape := markershape 
         x := [Inf]
         y := [Inf]
     end
     # add a series for the line, if it's not turned off
-    if haskey(plotattributes, :linewidth) && plotattributes[:linewidth] != :auto && plotattributes[:linewidth] > 0
+    if visible_line
         @series begin
             primary := false # no legend entry
             markershape := :none # ensure no markers
@@ -90,11 +92,13 @@ exptfplot
             label --> labels[i]
             seriescolor --> pal[i]
             if showline || get(plotattributes, :linewidth, 0) > 0
+                @info "A" step
                 seriestype := :samplemarkers
                 step := step
                 offset := step÷n *(i-1) + 1
                 return time[eachindex(T)], T
             else
+                @info "B" step
                 seriestype --> :scatter
                 offset = step÷n *(i-1) + 1
                 minlen = min(length(time), length(T))
@@ -512,7 +516,6 @@ exppplot
         @series begin
             seriestype --> :samplemarkers
             step --> length(p) ÷ 10
-            linewidth --> 2
             ylabel --> "Pressure"
             label --> defaultlabels[i]
             return t, p

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -11,7 +11,6 @@
     markershape = get(plotattributes, :markershape, :auto)
     visible_markers = markershape ∉ (:none, nothing) # if markershape isn't :none or nothing, it must be a symbol
     visible_line = lw == :auto || lw > 0 # if linewidth isn't :auto, it must be a number
-    @info "here" step offset
     @series begin
         seriestype := (visible_line ? :path : :scatter)
         markershape := (visible_markers ? markershape : :none)

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -36,39 +36,37 @@
     end
 end
 
-# TODO: these docs should be updated to have a more sensible API which allows turning off lines or markers
-# Also, nmarks=0 should not be all points: maybe NaN or Inf are better sentinels for that case.
 const nmarks_doc = """
 `nmarks` is an integer, indicating how many points to plot with markers, so that the number
-of markers is reasonable even with many data points. To plot all points (default), pass `nmarks=0`.
+of markers is reasonable even with many data points. To plot all points (default), pass `nmarks=Inf`.
 
 """
-const sampmarks_marker_doc = """
-`sampmarks=false` (default) will only show markers at selected points, while `sampmarks=true` will put a line through all points.
+const showline_doc = """
+This recipe defaults to showing data points without a line, but a line can be added by passing `showline=true` or specifying a `linewidth` (or `lw`).
 
 """
-const sampmarks_line_doc = """
-`sampmarks=false` (default) will only put a line through all points, while `sampmarks=true` will show markers at selected points.
+const showmarks_doc = """
+This recipe defaults to showing a line with no markers, but a line can be added by passing `showmarks=true` or specifying a `markershape` (or `ms`).
 
 """
 
 """
-    exptfplot(time, T1, [T2, ...]; nmarks=0, labsuffix=", exp.")
-    exptfplot!(time, T1, [T2, ...]; nmarks=0, labsuffix=", exp.")
+    exptfplot(time, T1, [T2, ...]; nmarks=Inf, showline=false, labsuffix=", exp.")
+    exptfplot!(time, T1, [T2, ...]; nmarks=Inf, showline=false, labsuffix=", exp.")
 
 Plot recipe for one or more experimentally measured product temperatures, all at same times.
 This recipe adds one series for each passed temperature series, with labels defaulting to `"T_{fi}"*labsuffix`.
 
 $nmarks_doc 
-$sampmarks_marker_doc
+$showline_doc
 """ 
 exptfplot
 @doc (@doc exptfplot) exptfplot!
 
 @userplot ExpTfPlot
-@recipe function f(tpe::ExpTfPlot; nmarks=0, sampmarks=false, labsuffix = ", exp.")
+@recipe function f(tpe::ExpTfPlot; nmarks=Inf, showline=false, labsuffix = ", exp.")
     time, Ts... = tpe.args
-    step = (nmarks == 0) ? 1 : (maximum([length(T) for T in Ts]) ÷ nmarks) 
+    step = (nmarks == Inf) ? 1 : (maximum([length(T) for T in Ts]) ÷ nmarks) 
     n = size(Ts, 1)
     # pal = palette(:Blues_5,)[end:-1:begin] # Requires Plots for palette, so hard-code this default
     pal = [RGB{Float64}(0.031,0.318,0.612), 
@@ -87,8 +85,7 @@ exptfplot
             markershape --> markers[i]
             label --> labels[i]
             seriescolor --> pal[i]
-            # TODO: get rid of this kwarg, it's a bad API
-            if sampmarks
+            if showline || get(plotattributes, :linewidth, 0) > 0
                 seriestype := :samplemarkers
                 step := step
                 offset := step÷n *(i-1) + 1
@@ -106,8 +103,8 @@ end
 
 
 """
-    exptvwplot(time, T1, [T2, ...]; skip=1, nmarks=0, labsuffix=", exp.")
-    exptvwplot!(time, T1, [T2, ...]; skip=1, nmarks=0, labsuffix=", exp.")
+    exptvwplot(time, T1, [T2, ...]; skip=1, nmarks=Inf, showline=false, labsuffix=", exp.")
+    exptvwplot!(time, T1, [T2, ...]; skip=1, nmarks=Inf, showline=false, labsuffix=", exp.")
 
 Plot recipe for a set of experimentally measured vial wall temperatures.
 This recipe adds one series for each passed temperature series, with labels defaulting to `"T_{vwi}"*labsuffix`.
@@ -115,13 +112,13 @@ This recipe adds one series for each passed temperature series, with labels defa
 the dotted line looks dotted even with noisy data.
 
 $nmarks_doc
-$sampmarks_marker_doc
+$showline_doc
 """
 exptvwplot
 @doc (@doc exptvwplot) exptvwplot!
 
 @userplot ExpTvwPlot
-@recipe function f(tpev::ExpTvwPlot; nmarks=0, sampmarks=false, skip=1, labsuffix=", exp.")
+@recipe function f(tpev::ExpTvwPlot; nmarks=Inf, showline=true, skip=1, labsuffix=", exp.")
     time, Ts... = tpev.args
     n = size(Ts, 1)
     # color = palette(:Blues_5)[end]
@@ -146,19 +143,19 @@ exptvwplot
             markerstrokecolor --> pal[i]
             markerstrokewidth --> 1.5
             # TODO: try to remove this kwarg, clunky API
-            if sampmarks
+            if showline || get(plotattributes, :linewidth, 0) > 0
                 linestyle --> :dash
                 time_skip = time[begin:skip:end]
                 T_skip = T[begin:skip:end]
                 seriestype := :samplemarkers
-                step = (nmarks == 0) ? 1 : (size(time_skip, 1) ÷ nmarks) 
+                step = (nmarks == Inf) ? 1 : (size(time_skip, 1) ÷ nmarks) 
                 step := step
                 offset := step÷n *(i-1) + 1
                 return time_skip, T_skip
             else
                 minlen = min(length(time), length(T))
                 seriestype --> :scatter
-                step = nmarks == 0 ? 1 : (size(time, 1) ÷ nmarks) 
+                step = nmarks == Inf ? 1 : (size(time, 1) ÷ nmarks) 
                 offset = step÷n *(i-1) + 1
                 return time[offset:step:minlen], T[offset:step:minlen]
             end
@@ -168,20 +165,20 @@ exptvwplot
 end
 
 """
-    modconvtplot(sols; sampmarks=false, labsuffix = ", model")
-    modconvtplot!(sols; sampmarks=false, labsuffix = ", model")
+    modconvtplot(sols; showmarks=false, labsuffix = ", model")
+    modconvtplot!(sols; showmarks=false, labsuffix = ", model")
 
 Plot recipe for one or multiple solutions to the Pikal model, e.g. the output of [`gen_sol_pd`](@ref LyoPronto.gen_sol_pd).
 This adds a series to the plot for each passed solution, with labels defaulting to `"T_{fi}"*labsuffix`.
 
-$sampmarks_line_doc
+$showmarks_doc
 """ 
 modconvtplot
 @doc (@doc modconvtplot) modconvtplot!
 
 
 @userplot ModConvTPlot
-@recipe function f(tpmc::ModConvTPlot; sampmarks=false, labsuffix = ", model")
+@recipe function f(tpmc::ModConvTPlot; showmarks=false, labsuffix = ", model")
     sols = tpmc.args
     # pal = palette(:Oranges_4).colors[end:-1:begin+1] # Requires Plots as dependency...
     pal = [
@@ -189,14 +186,14 @@ modconvtplot
     RGB{Float64}(0.992,0.553,0.235)
     RGB{Float64}(0.992,0.745,0.522)
     ]
-    markers = (:utriangle, :dtriangle, :cross)
+    showmarks = showmarks || get(plotattributes, :markershape, :none) != :none
     if length(sols) == 1
         labels = ["\$T_\\mathrm{f}\$"*labsuffix]
     else
         labels = ["\$T_\\mathrm{f$i}\$"*labsuffix for i in 1:length(sols)]
     end
 
-    if sampmarks 
+    if showmarks 
         for (i, sol) in enumerate(sols)
             t_nd = range(sol.t[begin], sol.t[end], length=101)
             time = t_nd*u"hr"
@@ -204,6 +201,7 @@ modconvtplot
             @series begin
                 seriestype := :samplemarkers
                 step := 20
+                offset = 10*(i-1)+1
                 markershape --> :auto
                 seriescolor --> pal[i]
                 label --> labels[i]
@@ -225,8 +223,8 @@ modconvtplot
 end
 
 """
-    modrftplot(sol, labsuffix=", model", sampmarks=false, trimend=0)
-    modrftplot!(sol, labsuffix=", model", sampmarks=false, trimend=0)
+    modrftplot(sol, labsuffix=", model", showmarks=false, trimend=0)
+    modrftplot!(sol, labsuffix=", model", showmarks=false, trimend=0)
 
 Plot recipe for one solution to the lumped capacitance model.
 
@@ -236,15 +234,16 @@ The optional argument `trimend` controls how many time points to trim from the e
 
 Since this is a recipe, any Plots.jl keyword arguments can be passed to modify the plot.
 
-$sampmarks_line_doc
+$showmarks_doc
 """
 modrftplot
 @doc (@doc modrftplot) modrftplot!
 
 @userplot ModRFTPlot
-@recipe function f(tpmr::ModRFTPlot; labsuffix = ", model", sampmarks=false, trimend=0)
+@recipe function f(tpmr::ModRFTPlot; showmarks=false, labsuffix = ", model", trimend=0)
     sol = tpmr.args[1]
-    if sampmarks
+    showmarks = showmarks || get(plotattributes, :markershape, :none) != :none
+    if showmarks
         t_nd = range(sol.t[begin], sol.t[end-trimend], length=31)
         step = 6
     else
@@ -254,7 +253,7 @@ modrftplot
     # color = palette(:Oranges_3)[end]
     color = RGB{Float64}(0.902,0.333,0.051)
     # Frozen temperature: tends to have a crazy time point at end
-    if sampmarks
+    if showmarks
         @series begin
             seriestype := :samplemarkers
             step := step

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -64,7 +64,11 @@ exptfplot
 @doc (@doc exptfplot) exptfplot!
 
 @userplot ExpTfPlot
-@recipe function f(tpe::ExpTfPlot; nmarks=Inf, showline=false, labsuffix = ", exp.")
+@recipe function f(tpe::ExpTfPlot; nmarks=Inf, showline=false, labsuffix = ", exp.", sampmarks=nothing)
+    if !isnothing(sampmarks)
+        Base.depwarn("The `sampmarks` keyword is deprecated and will be removed in a future release. Use `showline` instead.", :exptfplot; force=true)
+        showline = sampmarks
+    end
     time, Ts... = tpe.args
     step = (nmarks == Inf) ? 1 : (maximum([length(T) for T in Ts]) ÷ nmarks) 
     n = size(Ts, 1)
@@ -118,7 +122,11 @@ exptvwplot
 @doc (@doc exptvwplot) exptvwplot!
 
 @userplot ExpTvwPlot
-@recipe function f(tpev::ExpTvwPlot; nmarks=Inf, showline=true, skip=1, labsuffix=", exp.")
+@recipe function f(tpev::ExpTvwPlot; nmarks=Inf, showline=false, skip=1, labsuffix=", exp.", sampmarks=nothing)
+    if !isnothing(sampmarks)
+        Base.depwarn("The `sampmarks` keyword is deprecated and will be removed in a future release. Use `showline` instead.", :exptvwplot; force=true)
+        showline = sampmarks
+    end
     time, Ts... = tpev.args
     n = size(Ts, 1)
     # color = palette(:Blues_5)[end]
@@ -142,7 +150,6 @@ exptvwplot
             markercolor --> :white
             markerstrokecolor --> pal[i]
             markerstrokewidth --> 1.5
-            # TODO: try to remove this kwarg, clunky API
             if showline || get(plotattributes, :linewidth, 0) > 0
                 linestyle --> :dash
                 time_skip = time[begin:skip:end]
@@ -178,7 +185,11 @@ modconvtplot
 
 
 @userplot ModConvTPlot
-@recipe function f(tpmc::ModConvTPlot; showmarks=false, labsuffix = ", model")
+@recipe function f(tpmc::ModConvTPlot; showmarks=false, labsuffix = ", model", sampmarks=nothing)
+    if !isnothing(sampmarks)
+        Base.depwarn("The `sampmarks` keyword is deprecated and will be removed in a future release. Use `showmarks` instead.", :modconvtplot; force=true)
+        showmarks = sampmarks
+    end
     sols = tpmc.args
     # pal = palette(:Oranges_4).colors[end:-1:begin+1] # Requires Plots as dependency...
     pal = [
@@ -240,7 +251,11 @@ modrftplot
 @doc (@doc modrftplot) modrftplot!
 
 @userplot ModRFTPlot
-@recipe function f(tpmr::ModRFTPlot; showmarks=false, labsuffix = ", model", trimend=0)
+@recipe function f(tpmr::ModRFTPlot; showmarks=false, labsuffix = ", model", trimend=0, sampmarks=nothing)
+    if !isnothing(sampmarks)
+        Base.depwarn("The `sampmarks` keyword is deprecated and will be removed in a future release. Use `showmarks` instead.", :modrftplot; force=true)
+        showmarks = sampmarks
+    end
     sol = tpmr.args[1]
     showmarks = showmarks || get(plotattributes, :markershape, :none) != :none
     if showmarks
@@ -419,7 +434,9 @@ end
 @doc raw"""
     qrf_integrate(sol, RF_params)
 
-Compute the integral over time of each heat transfer mode in the lumped capacitance model.
+Compute the integral over time of each heat transfer mode in the lumped capacitance model. 
+RF_params should represent the same parameters used to generate the solution `sol`,
+which (if OrdinaryDiffEq doesn't change) can likely be accessed as `sol.prob.p`.
 
 Returns as a Dict{String, Quantity{...}}, with string keys `Qsub, Qshf, Qvwf, QRFf, QRFvw`.
 """

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -15,7 +15,7 @@
         y := [Inf]
     end
     # add a series for the line, if it's not turned off
-    if haskey(plotattributes, :linewidth) && plotattributes[:linewidth] > 0
+    if haskey(plotattributes, :linewidth) && plotattributes[:linewidth] != :auto && plotattributes[:linewidth] > 0
         @series begin
             primary := false # no legend entry
             markershape := :none # ensure no markers

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -11,6 +11,7 @@
     markershape = get(plotattributes, :markershape, :auto)
     visible_markers = markershape ∉ (:none, nothing) # if markershape isn't :none or nothing, it must be a symbol
     visible_line = lw == :auto || lw > 0 # if linewidth isn't :auto, it must be a number
+    @info "here" step offset
     @series begin
         seriestype := (visible_line ? :path : :scatter)
         markershape := (visible_markers ? markershape : :none)
@@ -165,7 +166,7 @@ exptvwplot
     else
         lens = [length(T) for T in Ts]
         # First get the number of actual points by dividing by `skip`, then divide by nmarks to get the step size
-        max(1, (maximum(lens ÷ skip) ÷ nmarks))
+        max(1, (maximum(lens)÷ skip ÷ nmarks))
     end
     for (i, T) in enumerate(Ts)
         @series begin

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -7,29 +7,37 @@
     n = length(y)
     sx, sy = x[offset:step:n], y[offset:step:n]
     # add an empty series with the correct type for legend markers
+    markershape = get(plotattributes, :markershape, :auto)
     @series begin
         seriestype := :path
-        markershape --> :auto
+        markershape := markershape 
         x := [Inf]
         y := [Inf]
     end
-    # add a series for the line
-    @series begin
-        primary := false # no legend entry
-        markershape := :none # ensure no markers
-        seriestype := :path
-        seriescolor := get(plotattributes, :seriescolor, :auto)
-        x := x
-        y := y
+    # add a series for the line, if it's not turned off
+    if haskey(plotattributes, :linewidth) && plotattributes[:linewidth] > 0
+        @series begin
+            primary := false # no legend entry
+            markershape := :none # ensure no markers
+            seriestype := :path
+            x := x
+            y := y
+        end
     end
-    # return  a series for the sampled markers
-    primary := false
-    seriestype := :scatter
-    markershape --> :auto
-    x := sx
-    y := sy
+    # add a series for the sampled markers, if they aren't turned off
+    if markershape ∉ (:none, nothing)
+        @series begin
+            primary := false
+            seriestype := :scatter
+            markershape := markershape
+            x := sx
+            y := sy
+        end
+    end
 end
 
+# TODO: these docs should be updated to have a more sensible API which allows turning off lines or markers
+# Also, nmarks=0 should not be all points: maybe NaN or Inf are better sentinels for that case.
 const nmarks_doc = """
 `nmarks` is an integer, indicating how many points to plot with markers, so that the number
 of markers is reasonable even with many data points. To plot all points (default), pass `nmarks=0`.
@@ -79,6 +87,7 @@ exptfplot
             markershape --> markers[i]
             label --> labels[i]
             seriescolor --> pal[i]
+            # TODO: get rid of this kwarg, it's a bad API
             if sampmarks
                 seriestype := :samplemarkers
                 step := step
@@ -136,6 +145,7 @@ exptvwplot
             markercolor --> :white
             markerstrokecolor --> pal[i]
             markerstrokewidth --> 1.5
+            # TODO: try to remove this kwarg, clunky API
             if sampmarks
                 linestyle --> :dash
                 time_skip = time[begin:skip:end]

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -9,10 +9,11 @@
     # add an empty series with the correct type for legend markers
     lw = get(plotattributes, :linewidth, :auto)
     markershape = get(plotattributes, :markershape, :auto)
-    visible_line = lw == :auto || lw > 0
+    visible_markers = markershape ∉ (:none, nothing) # if markershape isn't :none or nothing, it must be a symbol
+    visible_line = lw == :auto || lw > 0 # if linewidth isn't :auto, it must be a number
     @series begin
         seriestype := (visible_line ? :path : :scatter)
-        markershape := markershape 
+        markershape := (visible_markers ? markershape : :none)
         x := [Inf]
         y := [Inf]
     end
@@ -27,7 +28,7 @@
         end
     end
     # add a series for the sampled markers, if they aren't turned off
-    if markershape ∉ (:none, nothing)
+    if visible_markers
         @series begin
             primary := false
             seriestype := :scatter
@@ -39,8 +40,9 @@
 end
 
 const nmarks_doc = """
-`nmarks` is an integer, indicating how many points to plot with markers, so that the number
-of markers is reasonable even with many data points. To plot all points (default), pass `nmarks=Inf`.
+`nmarks` is an integer indicating how many points to plot with markers, so that the number
+of markers is reasonable even with many data points. To plot all points (default), pass 
+`nmarks=Inf`; to plot no points, pass `nmarks=0`.
 
 """
 const showline_doc = """
@@ -48,7 +50,7 @@ This recipe defaults to showing data points without a line, but a line can be ad
 
 """
 const showmarks_doc = """
-This recipe defaults to showing a line with no markers, but a line can be added by passing `showmarks=true` or specifying a `markershape` (or `ms`).
+This recipe defaults to showing a line with no markers, but markers can be added by passing `showmarks=true` or specifying a `markershape` (or `ms`).
 
 """
 
@@ -71,15 +73,25 @@ exptfplot
         Base.depwarn("The `sampmarks` keyword is deprecated and will be removed in a future release. Use `showline` instead.", :exptfplot; force=true)
         showline = sampmarks
     end
+    markers = (:circle, :square, :diamond, :hexagon)
     time, Ts... = tpe.args
-    step = (nmarks == Inf) ? 1 : (maximum([length(T) for T in Ts]) ÷ nmarks) 
+    step = if !isfinite(nmarks)
+        1 # If nmarks is Inf, we don't need to skip any points
+    elseif nmarks == 0
+        # If nmarks is 0, we don't want to plot any points, so set markers to :none
+        markers = (:none, :none, :none, :none)
+        1
+    else
+        # Skip points so that we only plot nmarks points, but at least 1 point
+        lens = [length(T) for T in Ts]
+        max(1, (maximum(lens) ÷ nmarks))
+    end
     n = size(Ts, 1)
     # pal = palette(:Blues_5,)[end:-1:begin] # Requires Plots for palette, so hard-code this default
     pal = [RGB{Float64}(0.031,0.318,0.612), 
            RGB{Float64}(0.192,0.51,0.741), 
            RGB{Float64}(0.42,0.682,0.839), 
            RGB{Float64}(0.741,0.843,0.906)]
-    markers = (:circle, :square, :diamond, :hexagon)
     
     if length(Ts) == 1
         labels = ["\$T_\\mathrm{f}\$"*labsuffix]
@@ -144,6 +156,17 @@ exptvwplot
     else
         labels = ["\$T_\\mathrm{vw$i}\$"*labsuffix for i in 1:n]
     end
+    step = if !isfinite(nmarks)
+        1 # If nmarks is Inf, we don't need to skip any points
+    elseif nmarks == 0
+        # If nmarks is 0, we don't want to plot any points, so set markers to :none
+        markers = (:none, :none, :none, :none)
+        1
+    else
+        lens = [length(T) for T in Ts]
+        # First get the number of actual points by dividing by `skip`, then divide by nmarks to get the step size
+        max(1, (maximum(lens ÷ skip) ÷ nmarks))
+    end
     for (i, T) in enumerate(Ts)
         @series begin
             markershape --> markers[i]
@@ -153,17 +176,17 @@ exptvwplot
             markerstrokecolor --> pal[i]
             markerstrokewidth --> 1.5
             minlen = min(length(time), length(T))
-            if showline || get(plotattributes, :linewidth, 0) > 0
+            if showline || get(plotattributes, :linewidth, 0) > 0 # Don't need to check for 
                 linestyle --> :dash
                 time_skip = time[begin:skip:minlen]
                 T_skip = T[begin:skip:minlen]
                 seriestype := :samplemarkers
-                step = (nmarks == Inf) ? 1 : (size(time_skip, 1) ÷ nmarks) 
-                step := step
+                step := step  
                 offset := step÷n *(i-1) + 1
                 return time_skip, T_skip
             else
                 seriestype --> :scatter
+                # Not using the :samplemarkers recipe, so manually skipping points to get nmarks
                 step = nmarks == Inf ? 1 : (size(time, 1) ÷ nmarks) 
                 offset = step÷n *(i-1) + 1
                 return time[offset:step:minlen], T[offset:step:minlen]
@@ -214,7 +237,7 @@ modconvtplot
             @series begin
                 seriestype := :samplemarkers
                 step := 20
-                offset = 10*(i-1)+1
+                offset := 10*(i-1)+1
                 markershape --> :auto
                 seriescolor --> pal[i]
                 label --> labels[i]
@@ -436,11 +459,11 @@ end
 @doc raw"""
     qrf_integrate(sol, RF_params)
 
-Compute the integral over time of each heat transfer mode in the lumped capacitance model. 
+Compute the integral over time of each heat transfer mode in the lumped capacitance model.
 RF_params should represent the same parameters used to generate the solution `sol`,
 which (if OrdinaryDiffEq doesn't change) can likely be accessed as `sol.prob.p`.
 
-Returns as a Dict{String, Quantity{...}}, with string keys `Qsub, Qshf, Qvwf, QRFf, QRFvw`.
+Returns a Dict{String, Quantity{...}}, with string keys `Qsub, Qshf, Qvwf, QRFf, QRFvw`.
 """
 function qrf_integrate(sol, RF_params)
 


### PR DESCRIPTION
I've been bothered for a while by the workarounds for taking markers off when using the `:samplemarkers` recipe type, and when to use or not use the `sampmarks` kwarg in recipes on top of it. Still deciding what a reasonable API is.